### PR TITLE
Feature/dry run fix

### DIFF
--- a/airflow_provider_tm1/operators/tm1_run_ti.py
+++ b/airflow_provider_tm1/operators/tm1_run_ti.py
@@ -95,7 +95,7 @@ class TM1RunTIOperator(BaseOperator):
 
 
         else:
-            print("Triggering TM1 " + self.process_name + " in dry-run mode with timeout " + str(self.tm1_timeout) + " with parameters ", self.tm1_ti_params)
+            print("Triggering TM1 " + self.process_name + " in dry-run mode with timeout " + str(self.timeout) + " with parameters ", self.tm1_params)
 
 def execute_aync(tm1, process_name: str, timeout: int, cancel_at_timeout: bool, **kwargs):
     additional_header = {'Prefer': 'respond-async'}

--- a/tests_integration/dags/airflow_test_dry_run_dag.py
+++ b/tests_integration/dags/airflow_test_dry_run_dag.py
@@ -1,0 +1,36 @@
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.utils.dates import days_ago
+
+from airflow_provider_tm1.operators.tm1_run_ti import TM1RunTIOperator
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 0,
+    'retry_delay': timedelta(minutes=5)
+}
+
+
+with DAG(
+        'airflow_test_dry_run_dag',
+        default_args=default_args,
+        schedule_interval=None,
+        start_date=days_ago(1),
+        tags=[],
+        catchup=False,
+        max_active_runs=1
+) as dag:
+    t1 = TM1RunTIOperator (
+        task_id='t1',
+        tm1_conn_id='tm1_conn',
+        process_name='airflow_test_success',
+        timeout=300,
+        tm1_dry_run=True
+    )
+
+    t1

--- a/tests_integration/integration_test.py
+++ b/tests_integration/integration_test.py
@@ -118,5 +118,13 @@ def test_airflow_test_execute_mdx_mapreduce():
     assert_airflow_dag_log_contains('Returned dataframe size: 2', output)
 
 
+def test_airflow_test_dry_run():
+    command = 'airflow dags test airflow_test_dry_run_dag'
+    result, output = run_docker_exec(command)
+
+    assert_airflow_dag_completed(result)
+    assert_airflow_dag_log_contains("Triggering TM1 airflow_test_success in dry-run mode with timeout 300 with parameters  {'async_request_mode': True}", output)
+
+
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
Created test for verifying if `TM1RunTIOperator` can execute task in dry run using `airflow_test_success` process as test case and added fix to resolve dry run logging error.

Steps to verify fix:
1. Added `test_airflow_test_dry_run` and run it without the fix in [commit 86093c3](https://github.com/airflow-provider-tm1/airflow-provider-tm1/commit/86093c3002df7fafb5153d0ad0180ef219658d42) -> `build-test` pipeline failed as expected: [test run 1](https://github.com/airflow-provider-tm1/airflow-provider-tm1/actions/runs/18005171761)
2. Added fix to `tm1_run_ti.py` modul in [commit 96a6f67](https://github.com/airflow-provider-tm1/airflow-provider-tm1/commit/96a6f67f5e1052a9d235d7abf61b463a42539876) and rerun test -> `build-test `pipeline run successfully: [test run 2](https://github.com/airflow-provider-tm1/airflow-provider-tm1/actions/runs/18005332540)